### PR TITLE
Edit configuration file to suppress jekyll complaint.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-name: Flex
+name: The CESE Hub
 markdown: redcarpet
-pygments: true
+highlighter: pygments
 url: http://cesehub.org/ 


### PR DESCRIPTION
I am using jekyll 3 and it complains that "pygments: true" is deprecated.

I also changed the site name in the configuration file.
