### PR TITLE
Ref issue #13 for site class we do not need to fix line-height.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -74,7 +74,6 @@ a:hover {
 .site {
   height: 100%;
   width: 100%;
-  line-height: 1.25em;
 }
 
 .title {


### PR DESCRIPTION
As css class site fix line height, titles or any font size of contents larger than this line height could reproduce issue #13 which makes the two different line texts overlapped.
