### PR TITLE
A demo for contributors to use github to host their customized CESE HUB

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-cesehub.org

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 name: The CESE Hub
 markdown: kramdown
 highlighter: rouge
-url: http://cesehub.org/ 
+baseurl: /cesehub

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,6 +21,9 @@
       <script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
   </head>
   <body>
+    <a href="https://github.com/tai271828">
+    <img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/82b228a3648bf44fc1163ef44c62fcc60081495e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_red_aa0000.png">
+    </a>
     <div class="site">
       <div class="sidebar" id="sidebar">
         <div class="header">


### PR DESCRIPTION
Please DO NOT accept this pull request.

This is a pull request to show how to use github to host a customized CESE Hub. Two action items are applied. They are:
- Removing CNAME, so contributors won't get the email spams from github against the duplicated domain name.
- Using the correct relative resource path, so the customized CESE Hub could show resources like images correctly with this domain name `https://<your-github-account-name>.github.io/cesehub`
